### PR TITLE
Fix npm publish auth for Yarn 3 (Berry)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         if: steps.tag_check.outputs.exists == 'false'
         run: yarn npm publish --access public
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         if: steps.tag_check.outputs.exists == 'false'
         run: yarn npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,3 @@
 nodeLinker: node-modules
 
-npmAuthToken: "${NPM_TOKEN}"
 npmPublishRegistry: "https://registry.npmjs.org"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,4 @@
 nodeLinker: node-modules
+
+npmAuthToken: "${NPM_TOKEN}"
+npmPublishRegistry: "https://registry.npmjs.org"


### PR DESCRIPTION
Yarn Berry ignores NODE_AUTH_TOKEN. Configure npmAuthToken in .yarnrc.yml to read from NPM_TOKEN env var, and update the workflow accordingly.